### PR TITLE
Fixed issue where hinge timing was overriding animation-name

### DIFF
--- a/stylesheets/animate/special/_hinge.scss
+++ b/stylesheets/animate/special/_hinge.scss
@@ -44,6 +44,6 @@
 
   @include animation-class($name, $class) {
     $selector: if($class == 'silent', '%animated', '.animated');
-    &#{$selector} { @include animation(2s ease both); }
+    &#{$selector} { @include animation($name 2s ease both); }
   }
 }


### PR DESCRIPTION
The override to the "hinge" animation's timing uses the shorthand, which results in inadvertently overriding the animation-name. 
